### PR TITLE
converted 2 functions to templates

### DIFF
--- a/include/basen.hpp
+++ b/include/basen.hpp
@@ -52,8 +52,25 @@ void decode_b64(Iter1 start, Iter1 end, Iter2 out);
 namespace impl
 {
 
-char extract_partial_bits(char value, unsigned int start_bit, unsigned int bits_count);
-char extract_overlapping_bits(char previous, char next, unsigned int start_bit, unsigned int bits_count);
+template<class char_type>
+char_type extract_partial_bits(char_type value, unsigned int start_bit, unsigned int bits_count)
+{
+	assert(start_bit + bits_count < 8);
+	char t1 = value >> (8 - bits_count - start_bit);
+	char t2 = t1 & ~(-1 << bits_count);
+	return t2;
+}
+
+template<class char_type>
+char_type extract_overlapping_bits(char_type previous, char_type next, unsigned int start_bit, unsigned int bits_count)
+{
+	assert(start_bit + bits_count < 16);
+	int bits_count_in_previous = 8 - start_bit;
+	int bits_count_in_next = bits_count - bits_count_in_previous;
+	char t1 = previous << bits_count_in_next;
+	char t2 = next >> (8 - bits_count_in_next) & ~(-1 << bits_count_in_next);
+	return (t1 | t2) & ~(-1 << bits_count);
+}
 
 struct b16_conversion_traits
 {
@@ -211,32 +228,14 @@ void encode(Iter1 start, Iter1 end, Iter2 out)
             // boundary
             char v;
             if (iter == end)
-                 v = extract_overlapping_bits(backlog, 0, start_bit, ConversionTraits::group_length());
+                 v = extract_overlapping_bits<char>(backlog, 0, start_bit, ConversionTraits::group_length());
             else
-                 v = extract_overlapping_bits(backlog, *iter, start_bit, ConversionTraits::group_length());
+                 v = extract_overlapping_bits<char>(backlog, *iter, start_bit, ConversionTraits::group_length());
             *out++ = ConversionTraits::encode(v);
             has_backlog = false;
             start_bit = (start_bit + ConversionTraits::group_length()) % 8;
         }
     }
-}
-
-char extract_partial_bits(char value, unsigned int start_bit, unsigned int bits_count)
-{
-    assert(start_bit + bits_count < 8);
-    char t1 = value >> (8 - bits_count - start_bit);
-    char t2 = t1 & ~(-1 << bits_count);
-    return t2;
-}
-
-char extract_overlapping_bits(char previous, char next, unsigned int start_bit, unsigned int bits_count)
-{
-    assert(start_bit + bits_count < 16);
-    int bits_count_in_previous = 8 - start_bit;
-    int bits_count_in_next = bits_count - bits_count_in_previous;
-    char t1 = previous << bits_count_in_next;
-    char t2 = next >> (8 - bits_count_in_next) & ~(-1 << bits_count_in_next) ;
-    return (t1 | t2) & ~(-1 << bits_count);
 }
 
 } // impl


### PR DESCRIPTION
Converted extract_partial_bits() and extract_overlapping_bits() functions to templates.
This fixes linker duplication errors when the .hpp is included in 2 projects, because these functions had their definition in the hpp file.
