### PR TITLE
Simplify calling by templating bitsize

### DIFF
--- a/example/basen_example.cpp
+++ b/example/basen_example.cpp
@@ -1,17 +1,17 @@
 /**
  * base-n, 1.0
  * Copyright (C) 2012 Andrzej Zawadzki (azawadzki@gmail.com)
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -28,6 +28,41 @@
 
 #include "basen.hpp"
 
+namespace bn
+{
+
+namespace impl
+{
+
+// Custom 8-bit conversion
+template<>
+struct conversion_traits_b<8>
+{
+    static size_t group_length()
+    {
+        return 3;
+    }
+
+    static char encode(unsigned int index)
+    {
+        const char* const dictionary = "01234567";
+        assert(index < strlen(dictionary));
+        return dictionary[index];
+    }
+
+    static char decode(char c)
+    {
+        if (c >= '0' && c <= '7') {
+            return c - '0';
+        }
+        return -1;
+    }
+};
+
+}
+
+} // namespace bn
+
 int main()
 {
     using namespace std;
@@ -36,20 +71,20 @@ int main()
 
     {
         string encoded;
-        bn::encode_b64(in.begin(), in.end(), back_inserter(encoded));
-        bn::decode_b64(encoded.begin(), encoded.end(), ostream_iterator<char>(cout, ""));
+        bn::encode<64>(in.begin(), in.end(), back_inserter(encoded));
+        bn::decode<64>(encoded.begin(), encoded.end(), ostream_iterator<char>(cout, ""));
         cout << endl;
     }
     {
         string encoded;
-        bn::encode_b32(in.begin(), in.end(), back_inserter(encoded));
-        bn::decode_b32(encoded.begin(), encoded.end(), ostream_iterator<char>(cout, ""));
+        bn::encode<32>(in.begin(), in.end(), back_inserter(encoded));
+        bn::decode<32>(encoded.begin(), encoded.end(), ostream_iterator<char>(cout, ""));
         cout << endl;
     }
     {
         string encoded;
-        bn::encode_b16(in.begin(), in.end(), back_inserter(encoded));
-        bn::decode_b16(encoded.begin(), encoded.end(), ostream_iterator<char>(cout, ""));
+        bn::encode<16>(in.begin(), in.end(), back_inserter(encoded));
+        bn::decode<16>(encoded.begin(), encoded.end(), ostream_iterator<char>(cout, ""));
         cout << endl;
     }
     {
@@ -58,37 +93,13 @@ int main()
             " dGhlIG1(pbmQsIHRoYXQgYnkgYSBwZXJzZXZlcmFuY2Ugb2YgZGVsaWdodCBpbiB0aGUgY29udGlu\n"
             "\rdWVkIGFuZCBpbmRlZmF0aWdhY*mxlIGdlbmVyYXRpb24gb2Yga25vd2xlZGdlLCBleGNlZWRzIHRo\n"
             "ZSBzaG9ydCB2ZWhlbWVuY2Ugb2YgYW55IGNhcm5hbCBwbGVhc3VyZS4";
-        bn::decode_b64(encoded.begin(), encoded.end(), ostream_iterator<char>(cout, ""));
+        bn::decode<64>(encoded.begin(), encoded.end(), ostream_iterator<char>(cout, ""));
         cout << endl;
     }
     {
-        // move the struct definition outside of main() for non-C++11 compilers
-        struct b8_custom
-        {
-            static size_t group_length()
-            {
-               return 3;
-            }
-
-            static char encode(unsigned int index)
-            {
-                const char* const dictionary = "01234567";
-                assert(index < strlen(dictionary));
-                return dictionary[index];
-            }
-
-            static char decode(char c)
-            {
-                if (c >= '0' && c <= '7') {
-                    return c - '0';
-                }
-                return -1;
-            }
-        };
         string encoded;
-        bn::impl::encode<b8_custom>(in.begin(), in.end(), back_inserter(encoded));
-        bn::impl::decode<b8_custom>(encoded.begin(), encoded.end(), ostream_iterator<char>(cout, ""));
+        bn::encode<8>(in.begin(), in.end(), back_inserter(encoded));
+        bn::decode<8>(encoded.begin(), encoded.end(), ostream_iterator<char>(cout, ""));
         cout << endl;
     }
 }
-


### PR DESCRIPTION
This simplifies the calling interface. However, one can now only define a single encoding scheme for a specific bit-count. If this is OK, then this PR simplifes things..