### PR TITLE
fix warning

### DIFF
--- a/include/basen.hpp
+++ b/include/basen.hpp
@@ -52,7 +52,7 @@ void decode_b64(Iter1 start, Iter1 end, Iter2 out);
 namespace impl
 {
 
-const int Error = -1;
+const char Error = -1;
 
 namespace {
 


### PR DESCRIPTION
fix warning
```
error: result of comparison of constant -1 with expression of type 'char' is always false
```