### PR TITLE
Add output padding during encode.

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,11 @@ struct b8_custom
                 }
                 return -1;
         }
+
+        static char padding()
+        {
+                return -1;
+        }
 };
 ...
 string encoded;

--- a/example/basen_example.cpp
+++ b/example/basen_example.cpp
@@ -57,7 +57,7 @@ int main()
             "IHNpbmd1bGFyIHBhc3Npb24gZnJvbS@BvdGhlciBhbmltYWxzLCB3aGljaCBpcyBhIGx1c3Qgb2Yg\n"
             " dGhlIG1(pbmQsIHRoYXQgYnkgYSBwZXJzZXZlcmFuY2Ugb2YgZGVsaWdodCBpbiB0aGUgY29udGlu\n"
             "\rdWVkIGFuZCBpbmRlZmF0aWdhY*mxlIGdlbmVyYXRpb24gb2Yga25vd2xlZGdlLCBleGNlZWRzIHRo\n"
-            "ZSBzaG9ydCB2ZWhlbWVuY2Ugb2YgYW55IGNhcm5hbCBwbGVhc3VyZS4";
+            "ZSBzaG9ydCB2ZWhlbWVuY2Ugb2YgYW55IGNhcm5hbCBwbGVhc3VyZS4=";
         bn::decode_b64(encoded.begin(), encoded.end(), ostream_iterator<char>(cout, ""));
         cout << endl;
     }
@@ -82,6 +82,11 @@ int main()
                 if (c >= '0' && c <= '7') {
                     return c - '0';
                 }
+                return -1;
+            }
+
+            static char padding()
+            {
                 return -1;
             }
         };


### PR DESCRIPTION
Some base64 library might required that decoded string's length is multiply of 4. This patch make we add the padding character automatically.

Follow by wikipedia : https://en.wikipedia.org/wiki/Base64
